### PR TITLE
networking improvement, working nicknames

### DIFF
--- a/global_constants.py
+++ b/global_constants.py
@@ -16,3 +16,5 @@ ZERO_ADDRESS = "0.0.0.0"
 PARTICIPATION_ADDITIONAL_SECONDS = 20
 MAIN_QML_PATH = "source_gui/main.qml"
 RANDOM_NUMBER_COUNT = 10
+CONNECTION_ATTEMPTS = 3                                     #How many tries could occur until peer is considered active
+RECONNECTION_DELAY = 5                                      #How much time has to be passed until reconnection to inactive peer

--- a/networking.py
+++ b/networking.py
@@ -92,9 +92,10 @@ class Networking(QObject):
             addr = json_array.get("addr")
             port = json_array.get("port")
             pk = json_array.get("pk")
+            nickname = json_array.get("nickname")
             try:
-                self.user.peer(addr, int(port), pk)
-                return jsonify({"status": "Connection established", "pk": self.user.public_key_to_pem()}), HTTPStatus.OK
+                self.user.peer(addr, int(port), pk, nickname)
+                return jsonify({"status": "Connection established", "pk": self.user.public_key_to_pem(), "nickname": self.user.nickname}), HTTPStatus.OK
             except Exception as e:
                 return jsonify({"error": str(e)}), HTTPStatus.SERVICE_UNAVAILABLE
 

--- a/source_gui/add_user.qml
+++ b/source_gui/add_user.qml
@@ -51,21 +51,6 @@ Page {
             }
         }
 
-        // Public Key Input
-        TextField {
-            id: pkField
-            placeholderText: "Public Key"
-            font.pixelSize: 16
-            height: 40
-            Layout.fillWidth: true
-            Layout.maximumWidth: maxInputWidth  // Set a maximum width for the input
-            background: Rectangle {
-                color: "#ffffff"
-                border.color: "#ccc"
-                radius: 5
-            }
-        }
-
         // Buttons Row
         RowLayout {
             spacing: 20

--- a/source_gui/chat_module.qml
+++ b/source_gui/chat_module.qml
@@ -44,6 +44,7 @@ Page {
         }
         updateUserModel();
         user.peersChanged.connect(updateUserModel);
+        user.nicknameChanged.connect(updateUserModel);
 
         user.messagesChanged.connect(function(newMessage) {
             if (newMessage !== ""){
@@ -194,7 +195,7 @@ Page {
                             // Use a single Text element to concatenate the name and IP address
                             Text {
                                 anchors.centerIn: parent  // Center the text within the parent
-                                text: '<font color="black">' + model.nickname + ' </font><font color="gray"><i>(' + model.addr + ":" + model.port + ')</i></font>'
+                                text: '<span style="color: black; ">' + model.nickname + ' </span><span style="color: gray; "><i>(' + model.addr + ":" + model.port + ')</i></span>'
                                 color: "#000"
                                 font.pixelSize: 12
                                 horizontalAlignment: Text.AlignHCenter  // Center horizontally
@@ -206,6 +207,9 @@ Page {
                         Popup {
                             id: popup
                             width: parent.width
+                            modal: true
+                            focus: true
+                            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
                             ColumnLayout {
                                 Button {
@@ -222,7 +226,14 @@ Page {
                                         stackView.push("chat_module.qml");
                                     }
                                 }
-
+                                Button {
+                                    height: userRectangle.height / 2
+                                    text: "Change nickname"
+                                    onClicked: {
+                                        changeNicknamePopup.visible = true;
+                                        popup.visible = false;
+                                    }
+                                }
                                 Button {
                                     height: userRectangle.height / 2
                                     text: "Get public key"
@@ -250,6 +261,50 @@ Page {
                                 }
                             }
                         }
+
+                        Popup {
+                            id: changeNicknamePopup
+                            width: parent.width
+                            modal: true
+                            focus: true
+                            visible: false  // Początkowo ukryty
+                            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+                            ColumnLayout {
+                                anchors.fill: parent
+                                spacing: 10
+
+                                TextField {
+                                    id: newNicknameField
+                                    placeholderText: "Enter new nickname"
+                                    Layout.fillWidth: true
+                                }
+
+                                RowLayout {
+                                    Layout.alignment: Qt.AlignCenter
+                                    spacing: 10
+
+                                    Button {
+                                        text: "Cancel"
+                                        onClicked: {
+                                            changeNicknamePopup.visible = false; // Zamknij Popup
+                                        }
+                                    }
+
+                                    Button {
+                                        text: "Confirm"
+                                        onClicked: {
+                                            if (newNicknameField.text.trim() !== "") {
+                                                user.change_peers_nickname(model.addr, model.port, newNicknameField.text);
+                                                changeNicknamePopup.visible = false; // Zamknij Popup
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                        }
+
                     }
                 }
 

--- a/source_gui/user.qml
+++ b/source_gui/user.qml
@@ -41,20 +41,5 @@ Page {
                     color: "black"
                 }
             }
-            RowLayout{
-                Text {
-                    id: pkText
-                    Layout.alignment: Qt.AlignHCenter
-                    text: "Public Key: "
-                    font.pixelSize: 20
-                    color: "black"
-                }
-                TextField {
-                    text: pk
-                    Layout.alignment: Qt.AlignHCenter
-                    font.pixelSize: 20
-                    color: "black"
-                }
-            }
     }
 }


### PR DESCRIPTION
- Better exception handling for consensus checking
- Set “inactive” status for a peer that cannot be connected to
- Added option to set nicknames for individual peers
- Removed unnecessary public key's field in both user profile and adding new user page